### PR TITLE
Fix `BudouXText` bug when using a language not supported by BudouX.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "BudouX.swift",
+    defaultLocalization: "en",
     products: [
         .library(
             name: "BudouX",

--- a/Sources/BudouX/BudouX.swift
+++ b/Sources/BudouX/BudouX.swift
@@ -6,5 +6,8 @@
 //
 //
 
+/// List of natural languages supported by BudouX parser.
+public let supportedNaturalLanguages = ["ja"]
+
 /// ML Model acts as namespace. See JaKNBCModel.swift.
 public struct Model {}

--- a/Sources/BudouX/Resources/en.lproj/Localizable.strings
+++ b/Sources/BudouX/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+
+
+  Created by treastrain on 2022/01/16.
+  
+*/
+
+"net.cyan-stivy.budoux-swift.LocalizationFinder.Key" = "en";

--- a/Sources/BudouX/Resources/ja.lproj/Localizable.strings
+++ b/Sources/BudouX/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+
+
+  Created by treastrain on 2022/01/16.
+  
+*/
+
+"net.cyan-stivy.budoux-swift.LocalizationFinder.Key" = "ja";

--- a/Sources/BudouX/SwiftUI/BudouXText.swift
+++ b/Sources/BudouX/SwiftUI/BudouXText.swift
@@ -17,7 +17,10 @@
     /// - Returns: The `SwiftUI.Text` initialized from the result of translating by the BudouX parser.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     public func BudouXText(verbatim content: String, parser: Parser = .init(), threshold: Int = Parser.defaultThreshold) -> Text {
-        Text(verbatim: parser.translate(sentence: content, threshold: threshold))
+        guard supportedNaturalLanguages.contains(currentLocalizationKey) else {
+            return Text(verbatim: content)
+        }
+        return Text(verbatim: parser.translate(sentence: content, threshold: threshold))
     }
 
     // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -35,7 +38,10 @@
     ///   - threshold: A threshold score for BudouX parser to control the granularity of output chunks.
     /// - Returns: The `SwiftUI.Text` initialized from the result of sending `localizedString(forKey:value:table:)` to bundle, passing the specified key, value, and tableName, and translating by the BudouX parser.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-    public func BudouXText(_ key: String, tableName: String? = nil, bundle: Bundle? = nil, comment: StaticString? = nil, parser: BudouX.Parser = .init(), threshold: Int = Parser.defaultThreshold) -> Text {
+    public func BudouXText(_ key: String, tableName: String? = nil, bundle: Bundle? = nil, comment: StaticString? = nil, parser: Parser = .init(), threshold: Int = Parser.defaultThreshold) -> Text {
+        guard supportedNaturalLanguages.contains(currentLocalizationKey) else {
+            return Text(LocalizedStringKey(key), tableName: tableName, bundle: bundle, comment: comment)
+        }
         let content = NSLocalizedString(key, tableName: tableName, bundle: bundle ?? .main, comment: (comment?.description ?? ""))
         return BudouXText(verbatim: content, parser: parser, threshold: threshold)
     }

--- a/Sources/BudouX/Utils.swift
+++ b/Sources/BudouX/Utils.swift
@@ -36,3 +36,8 @@ func bisectRight(arr: [Int], i: Int) -> Int {
 
 /// The separator string to specify breakpoints.
 let separator = "_"
+
+/// A key to identify the language of the execution environment.
+var currentLocalizationKey: String {
+    NSLocalizedString("net.cyan-stivy.budoux-swift.LocalizationFinder.Key", tableName: "Localizable", bundle: .module, comment: "")
+}


### PR DESCRIPTION
Thank you for approving #11!
I'm sorry there is a bug in `BudouXText` that I added in that pull request, I didn't anticipate at the time.

When `BudouXText` is used in a language that BudouX does not support (currently non-Japanese), no translation by `BudouX.Parser`.

(In the example screenshot below, the line break position of "brown" is incorrect.)

|non-`ja` Before|non-`ja` After|`ja` (No change)|
|:-:|:-:|:-:|
|![Screen Shot 2022-01-17 at 1 16 31](https://user-images.githubusercontent.com/13805382/149668887-746d26a3-dc22-42a4-8e7a-6873a3308a47.png)|![Screen Shot 2022-01-17 at 1 16 51](https://user-images.githubusercontent.com/13805382/149668890-8baded5f-9b09-41e4-a2f6-efd3877e9ff4.png)|![Screen Shot 2022-01-17 at 1 20 04](https://user-images.githubusercontent.com/13805382/149668892-8ee8579e-3daf-4b35-8934-88b58a5db431.png)|