### PR TITLE
Support loading custom model

### DIFF
--- a/Sources/BudouX/CustomModel.swift
+++ b/Sources/BudouX/CustomModel.swift
@@ -1,0 +1,19 @@
+//
+//  CustomModel.swift
+//  
+//
+//  Created by griffin-stewie on 2023/06/15.
+//  
+//
+
+import Foundation
+
+public struct CustomModel: Model {
+    public let supportedNaturalLanguages: Set<String>
+    public let featureAndScore: [String: [String: Int]]
+
+    public init(modelJSON: Data, supportedNaturalLanguages: Set<String>) throws {
+        featureAndScore = try JSONDecoder().decode([String: [String: Int]].self, from: modelJSON)
+        self.supportedNaturalLanguages = supportedNaturalLanguages
+    }
+}

--- a/Sources/BudouX/CustomModel.swift
+++ b/Sources/BudouX/CustomModel.swift
@@ -12,6 +12,12 @@ public struct CustomModel: Model {
     public let supportedNaturalLanguages: Set<String>
     public let featureAndScore: [String: [String: Int]]
 
+    public init(fileURL: URL, supportedNaturalLanguages: Set<String>) throws {
+        precondition(fileURL.isFileURL)
+        let data = try Data(contentsOf: fileURL)
+        try self.init(modelJSON: data, supportedNaturalLanguages: supportedNaturalLanguages)
+    }
+
     public init(modelJSON: Data, supportedNaturalLanguages: Set<String>) throws {
         featureAndScore = try JSONDecoder().decode([String: [String: Int]].self, from: modelJSON)
         self.supportedNaturalLanguages = supportedNaturalLanguages


### PR DESCRIPTION
Currently, it was necessary to either use the included JaKNBCModel-like model as is or prepare a Model-compliant model yourself. By using `CustomModel`, you can easily use the JSON file of the learning model for BudouX.Parser.
