### PR TITLE
bump version v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Support Swift Package Manager only. There are no plans to support other package 
 
 ```swift
 package.append(
-    .package(url: "https://github.com/griffin-stewie/BudouX.swift", from: "0.9.0")
+    .package(url: "https://github.com/griffin-stewie/BudouX.swift", from: "0.10.0")
 )
 
 package.targets.append(

--- a/Sources/budoux-swift/MainCommand.swift
+++ b/Sources/budoux-swift/MainCommand.swift
@@ -45,7 +45,7 @@ struct MainCommand: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "budoux-swift",
         abstract: "budoux-swift is BudouX swift port. BudouX is the successor to Budou, the machine learning powered line break organizer tool.",
-        version: "0.9.0"
+        version: "0.10.0"
     )
 
     @OptionGroup()


### PR DESCRIPTION
This version of BudouX.swift is equivalent to https://github.com/google/budoux/commit/8df9b5d936a14f37a9ea45d22f64ee5b7c16fc8a.